### PR TITLE
fix: Prevent double locking on x11 idle hook

### DIFF
--- a/scripts/idle-hook
+++ b/scripts/idle-hook
@@ -5,22 +5,15 @@ minute() {
   echo $(($1*60))
 }
 
-dim() {
-	"echo $(light -G) > /tmp/screenBrightnessValue && light -S 5"
-}
-restore() {
-	"[ -f /tmp/screenBrightnessValue ] && light -S $(cat /tmp/screenBrightnessValue) && rm /tmp/screenBrightnessValue"
-}
-
 # Run xidlehook
 xidlehook \
   --not-when-fullscreen \
   --not-when-audio \
-  --timer normal "$(minute 2)" \
+  --timer normal 2 \
 		'echo $(light -G) > /tmp/screenBrightnessValue && light -S 5' \
     '[ -f /tmp/screenBrightnessValue ] && light -S $(cat /tmp/screenBrightnessValue) && rm /tmp/screenBrightnessValue' \
-    --timer primary "$(minute 4)" \
-    '[ -f /tmp/screenBrightnessValue ] && light -S $(cat /tmp/screenBrightnessValue) && rm /tmp/screenBrightnessValue; custom-lock' \
+    --timer primary 3 \
+    ' ! pgrep i3lock && [ -f /tmp/screenBrightnessValue ] && light -S $(cat /tmp/screenBrightnessValue) && rm /tmp/screenBrightnessValue && custom-lock' \
     '' \
     --timer normal "$(minute 30)" \
     'systemctl suspend' \


### PR DESCRIPTION
* Prevent double locking when running x-idle-hook

close #89